### PR TITLE
Fix 3D Model Visualization

### DIFF
--- a/src/components/handlers/Model3D.vue
+++ b/src/components/handlers/Model3D.vue
@@ -4,16 +4,15 @@
 	:cameraPosition="{ x: 1, y: -5, z: -100 }"
 	:filePath="src"
 	:lights="lights"
-	:crossOrigin="anonymous"
 	:backgroundAlpha="0"
+	:fileType="modelType"
 	class="img"
 	></vue3dLoader>
 </template>
 
 <script lang="ts" setup>
 import { vue3dLoader } from "vue-3d-loader";
-
-const props = defineProps(['src'])
+const props = defineProps(['src','modelType'])
 const lights = [
   {
     type: "AmbientLight",

--- a/src/components/handlers/Selector.vue
+++ b/src/components/handlers/Selector.vue
@@ -83,11 +83,11 @@ async function load() {
 			containerAttrs: { class: ['data-container', 'column-container', 'padding'] }
 		}
 	}
-	else if (tags['Content-Type'] === 'model/stl' || tags['File-Name']?.slice(-4) === '.stl') {
+	else if (tags['Content-Type'] === 'model/stl') {
 		data.loaded = true
 		return data.handler = {
 			is: markRaw(Model3D),
-			attrs: { src: gatewayLink.value + '.stl' },
+			attrs: { src: gatewayLink.value, modelType: "stl" },
 			containerAttrs: { class: ['img-container'] }
 		}
 	}


### PR DESCRIPTION
This new fix makes use of the `Content-Type` property in the file metadata: `'model/stl` - if the `Content-Type` is a match, then `vue-3d-loader` is instead instructed to use the `fileType` property to select the proper loader - leaving the `url src` property untouched.

This makes the data fetching logic work successfully to download the file as well as `vue-3d-loader` to preview it on the web browser.

For now the support is for stl 3d model file types, in the future more types may be added if needed (to be tested).

Closes #3 